### PR TITLE
Update ingest scripts

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,9 +1,10 @@
 ---
-:concurrency: 5
+:concurrency: 4
 staging:
-  :concurrency: 10
+  :concurrency: 4
 production:
-  :concurrency: 20
+  :concurrency: 4
 :queues:
   - default
+  - ingest
   


### PR DESCRIPTION
Closes #4 

- creates lower priority ingest que to help with proper ingest flow
- reduces concurrency to reduce failed calls to Fedora
- protects against missing fgdc metadata elements